### PR TITLE
Improve speed of match API (fix #43)

### DIFF
--- a/src/dispensary.js
+++ b/src/dispensary.js
@@ -16,6 +16,7 @@ var _files = [];
 export default class Dispensary {
 
   constructor(config={}, _libraries=null, _hashes=DEFAULT_HAHES_FILE) {
+    this._cachedMatches = null;
     this._libraries = _libraries;
     this.libraryFile = DEFAULT_LIBRARY_FILE;
     this.hashesFile = _hashes;
@@ -62,15 +63,22 @@ export default class Dispensary {
   // Matches only against cached hashes; this is the API external apps and
   // libraries would use.
   match(contents, _hashesFile=DEFAULT_HAHES_FILE) {
-    var hashes = this._getCachedHashes(_hashesFile);
+    if (this._cachedMatches === null) {
+      this._cachedMatches = {};
+      var hashes = this._getCachedHashes(_hashesFile);
 
-    for (let hashEntry of hashes) {
-      let hash = hashEntry.split(' ')[0];
-      let library = hashEntry.split(' ')[1];
+      for (let hashEntry of hashes) {
+        let hash = hashEntry.split(' ')[0];
+        let library = hashEntry.split(' ')[1];
 
-      if (createHash(contents) === hash) {
-        return library;
+        this._cachedMatches[hash] = library;
       }
+    }
+
+    var contentsHash = createHash(contents);
+
+    if (this._cachedMatches.hasOwnProperty(contentsHash)) {
+      return this._cachedMatches[contentsHash];
     }
 
     return false;

--- a/tests/test.dispensary.js
+++ b/tests/test.dispensary.js
@@ -102,6 +102,23 @@ describe('Dispensary', function() {
       });
   });
 
+  it('should save hash object after first match run', () => {
+    var h = '9320ea11f6d427aec4949634dc8676136b2fa8cdad289d22659b44541abb8c51';
+    h += ' mylib.1.0.0.js';
+
+    var dispensary = new Dispensary();
+    sinon.stub(dispensary, '_getCachedHashes', () => {
+      return [h];
+    });
+    assert.equal(dispensary._cachedMatches, null);
+    dispensary.match('hasher');
+    dispensary.match('hasher2');
+    dispensary.match('hasher3');
+
+    assert.instanceOf(dispensary._cachedMatches, Object);
+    assert.lengthOf(Object.keys(dispensary._cachedMatches), 1);
+  });
+
   it('should match a hash', () => {
     var h = '9320ea11f6d427aec4949634dc8676136b2fa8cdad289d22659b44541abb8c51';
     h += ' mylib.1.0.0.js';


### PR DESCRIPTION
I did this stupid the first time, who even knows why.

Added a test for this and noticed a serious speed-up in usage on the linter after this patch was applied.

r?