### PR TITLE
Move array-from out of devDeps (close #42)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/mozilla/dispensary#readme",
   "devDependencies": {
-    "array-from": "2.0.2",
     "babel-core": "6.4.5",
     "babel-eslint": "5.0.0-beta9",
     "babel-loader": "6.2.1",
@@ -53,6 +52,7 @@
     "webpack-dev-server": "1.14.1"
   },
   "dependencies": {
+    "array-from": "2.0.2",
     "async": "^1.5.2",
     "bunyan": "^1.5.1",
     "eslint": "1.10.3",


### PR DESCRIPTION
This needs to be here so our usage of `Array.from` doesn't break once we're being used as a dependency (in the linter).