### PR TITLE
fix #290: use .npmignore for package contents

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+.babelrc
+.eslintrc
+.jscsrc
+.npmignore
+.nvmrc
+.travis.yml
+CONTRIBUTING.md
+Gruntfile.js
+coverage
+node_modules
+src
+tasks
+tests
+webpack.config.js

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "update": "npm run build && ./bin/dispensary > src/hashes.txt",
     "start": "node -e \"require('grunt').cli()\" null start",
     "build": "node -e \"require('grunt').cli()\" null build",
-    "test": "LANG='en_US.UTF-8' node -e \"require('grunt').cli()\" null test"
+    "test": "LANG='en_US.UTF-8' node -e \"require('grunt').cli()\" null test",
+    "prepublish": "npm test && npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This also adds `npm test && npm build` as the `prepublish` script to make sure the latest `dist/dispensary.js` is built before publishing.