### PR TITLE
Remove unused minVersion key

### DIFF
--- a/src/dispensary.js
+++ b/src/dispensary.js
@@ -138,33 +138,26 @@ export default class Dispensary {
     var files = [];
 
     for (let version of library.versions) {
-      var minVersion = library.minVersion;
-      // If there is a `minVersion`,
-      // make sure `version` is equal or higher than `minVersion`.
-      // `naturalCompare` behaves like an ordinary 'compare'.
-      if (!minVersion ||
-           (minVersion && naturalCompare(minVersion, version) <= 0)) {
-        if (library.filename) {
-          files.push({
-            file: library.filename,
-            fileOut: library.filenameOutput || library.filename,
-            index: index,
-            library: library,
-            version: version,
-            minified: false,
-          });
-        }
+      if (library.filename) {
+        files.push({
+          file: library.filename,
+          fileOut: library.filenameOutput || library.filename,
+          index: index,
+          library: library,
+          version: version,
+          minified: false,
+        });
+      }
 
-        if (library.filenameMinified) {
-          files.push({
-            file: library.filenameMinified,
-            fileOut: library.filenameMinifiedOutput || library.filenameMinified,
-            index: index,
-            library: library,
-            version: version,
-            minified: true,
-          });
-        }
+      if (library.filenameMinified) {
+        files.push({
+          file: library.filenameMinified,
+          fileOut: library.filenameMinifiedOutput || library.filenameMinified,
+          index: index,
+          library: library,
+          version: version,
+          minified: true,
+        });
       }
     }
 

--- a/src/libraries.json
+++ b/src/libraries.json
@@ -115,7 +115,6 @@
       "1.3.2",
       "1.3.3"
     ],
-    "minVersion": "1.0.0",
     "filename": "backbone.js",
     "filenameMinified": "backbone-min.js",
     "url": "https://raw.githubusercontent.com/jashkenas/backbone/$VERSION/$FILENAME"
@@ -209,7 +208,6 @@
       "0.8.9",
       "0.9.0"
     ],
-    "minVersion": "0.7.0",
     "filename": "purify.js",
     "filenameMinified": "purify.min.js",
     "url": "https://raw.githubusercontent.com/cure53/DOMPurify/$VERSION/src/$FILENAME",
@@ -268,7 +266,6 @@
       "3.2.0",
       "3.2.1"
     ],
-    "minVersion": "1.0.1",
     "filename": "jquery-$VERSION.js",
     "filenameOutput": "jquery.js",
     "filenameMinified": "jquery-$VERSION.min.js",
@@ -313,7 +310,6 @@
       "2.18.0",
       "2.18.1"
     ],
-    "minVersion": "2.9.0",
     "filename": "moment.js",
     "filenameMinified": "moment.min.js",
     "url": "https://raw.githubusercontent.com/moment/moment/$VERSION/$FILENAME",
@@ -369,7 +365,6 @@
       "15.6.0",
       "15.6.1"
     ],
-    "minVersion": "0.8.0",
     "filename": "react.js",
     "filenameMinified": "react.min.js",
     "url": "https://unpkg.com/react@$VERSION/dist/$FILENAME"
@@ -400,7 +395,6 @@
       "15.4.2",
       "15.5.4"
     ],
-    "minVersion": "0.14.0",
     "filename": "react-dom.js",
     "filenameMinified": "react-dom.min.js",
     "url": "https://unpkg.com/react-dom@$VERSION/dist/$FILENAME"
@@ -432,7 +426,6 @@
       "1.8.2",
       "1.8.3"
     ],
-    "minVersion": "1.2.0",
     "filename": "underscore.js",
     "filenameMinified": "underscore-min.js",
     "url": "https://raw.github.com/jashkenas/underscore/$VERSION/$FILENAME"
@@ -442,7 +435,6 @@
     "versions": [
       "0.1.1"
     ],
-    "minVersion": "0.1.1",
     "filename": "browser-polyfill.js",
     "filenameMinified": "browser-polyfill.min.js",
     "url": "https://unpkg.com/webextension-polyfill@$VERSION/dist/$FILENAME"

--- a/tests/fixtures/test_libraries.json
+++ b/tests/fixtures/test_libraries.json
@@ -7,7 +7,6 @@
       "1.1.1",
       "1.1.2"
     ],
-    "minVersion": "1.0.0",
     "filename": "backbone.js",
     "filenameMinified": "backbone-min.js",
     "url": "https://raw.githubusercontent.com/jashkenas/backbone/$VERSION/$FILENAME"

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -4,7 +4,6 @@ export function unexpectedSuccess() {
 
 export const FAKE_LIBRARIES = {
   angular: {
-    minVersion: '1.0.1',
     path: 'angular.js',
     pathToMinified: 'angular.min.js',
     useNPM: true,

--- a/tests/test.dispensary.js
+++ b/tests/test.dispensary.js
@@ -416,27 +416,6 @@ describe('Dispensary', function() {
     ]);
   });
 
-  it('should respect minVersion', () => {
-    var dispensary = new Dispensary();
-    var library = {
-      minVersion: '1.1.1',
-      filename: 'mylibrary.js',
-      versions: ['1.1.0', '1.1.1'],
-    };
-    var files = dispensary._getAllFilesFromLibrary(library, 2);
-
-    assert.deepEqual(files, [
-      {
-        file: 'mylibrary.js',
-        fileOut: 'mylibrary.js',
-        index: 2,
-        library: library,
-        version: '1.1.1',
-        minified: false,
-      },
-    ]);
-  });
-
   it('should sort hashes output', () => {
     var dispensary = new Dispensary();
     sinon.stub(dispensary, '_getCachedHashes', () => {


### PR DESCRIPTION
`minVersion` is a relict from when we were using npm to fetch versions.