### PR TITLE
Move eslint to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-preset-stage-2": "6.24.1",
     "chai": "4.1.0",
     "coveralls": "2.13.1",
+    "eslint": "4.3.0",
     "grunt": "1.0.1",
     "grunt-contrib-clean": "1.1.0",
     "grunt-contrib-copy": "1.0.0",
@@ -60,7 +61,6 @@
   "dependencies": {
     "array-from": "2.1.1",
     "async": "^2.0.0",
-    "eslint": "4.3.0",
     "natural-compare-lite": "^1.4.0",
     "pino": "^4.6.0",
     "request": "^2.81.0",


### PR DESCRIPTION
We shouldn't need eslint outside of running tests so it should be in devDependencies.