### PR TITLE
Replace babel-preset-es2015 by babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015", "stage-2"],
+  "presets": ["env", "stage-2"],
   "plugins": [
     "transform-array-from",
     "transform-class-properties",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-plugin-transform-array-from": "^1.0.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-stage-2": "^6.24.1",
     "chai": "^4.1.1",
     "coveralls": "^3.0.0",


### PR DESCRIPTION
`npm WARN deprecated babel-preset-es2015@6.24.1: 🙌  Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update!`