### PR TITLE
Updated snyk to 1.227.0 to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "mocha": "~6.2.0",
     "raw-loader": "~3.1.0",
     "sinon": "~7.4.0",
-    "snyk": "^1.192.3",
+    "snyk": "^1.227.0",
     "webpack": "~4.40.0"
   },
   "dependencies": {


### PR DESCRIPTION
This outdated version of snyk depends on a vulnerable version of lodash@4.17.11
https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/