### PR TITLE
Remove 'output' and 'pretty' option

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -15,18 +15,6 @@ export default argv
     default: 'fatal',
     choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace'],
   })
-  .option('output', {
-    alias: 'o',
-    describe: 'The type of output to generate',
-    type: 'string',
-    default: 'json',
-    choices: ['json', 'text'],
-  })
-  .option('pretty', {
-    describe: 'Prettify JSON output',
-    type: 'boolean',
-    default: false,
-  })
   .option('max', {
     describe: 'Maximum number of concurrent HTTP requests',
     type: 'string',

--- a/src/const.js
+++ b/src/const.js
@@ -1,5 +1,0 @@
-export const COMMANDS = {
-  default: 'output',
-  output: 'output',
-  update: 'update',
-};

--- a/src/dispensary.js
+++ b/src/dispensary.js
@@ -5,7 +5,6 @@ import request from 'request';
 import naturalCompare from 'natural-compare-lite';
 
 import HASHES from 'hashes.txt';
-import { COMMANDS } from 'const';
 import createHash from 'hasher';
 import log from 'logger';
 import { urlFormat } from 'utils';
@@ -18,8 +17,7 @@ export default class Dispensary {
     this._cachedHashes = null;
     this._libraries = _libraries;
     this._pathToHashes = './src/hashes.txt';
-    // Default command is "output"
-    this.command = COMMANDS.default;
+    this.command = 'output';
     this.libraryFile = config.libraries;
     this.maxHTTPRequests = 35;
 

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -28,20 +28,9 @@ describe('Basic CLI tests', () => {
     expect(args.max).toEqual('35');
   });
 
-  it('should default add-on output to "json"', () => {
-    const args = cli.parse(['angular']);
-    expect(args.output).toEqual('json');
-    expect(args.o).toEqual('json');
-  });
-
   it('should default stack to false', () => {
     const args = cli.parse(['angular']);
     expect(args.stack).toEqual(false);
-  });
-
-  it('should default pretty to false', () => {
-    const args = cli.parse(['angular']);
-    expect(args.pretty).toEqual(false);
   });
 
   it('should default boring to false', () => {
@@ -56,14 +45,5 @@ describe('Basic CLI tests', () => {
         'Should not fail with zero arguments',
       ),
     ).toBeFalsy();
-  });
-
-  it('should show error if incorrect output', () => {
-    cli.parse(['-o', 'false', 'whatevs']);
-    expect(
-      testContext.fakeFail.calledWithMatch(
-        'Invalid values:\n  Argument: output, Given: "false"',
-      ),
-    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
'pretty' was only used for json output.