### PR TITLE
Fix travis deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "npm run clean && webpack",
     "clean": "rimraf /dist /coverage",
     "eslint": "eslint .",
-    "prepublishOnly": "npm test && npm run build",
+    "prepublishOnly": "npm run test-ci",
     "prettier": "pretty-quick --branch master",
     "prettier-ci": "prettier -c '**'",
     "prettier-full": "prettier --write '**'",


### PR DESCRIPTION
`npm test` was running `jest tests/ --watch` which caused the job to never finish.

Job failure: https://travis-ci.org/mozilla/dispensary/jobs/613450849