### PR TITLE
Add libraries updates section in README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ sudo: false
 node_js:
   - "10"
   - "12"
-script: npm run test-ci
+script:
+  - npm run test-ci
+  - bin/build-doc && git diff --name-only | grep 'README.md' && echo -e "\nPlease run 'bin/build-doc'" && exit 1 || exit 0
+
 notifications:
   irc:
     channels:

--- a/README.md
+++ b/README.md
@@ -35,3 +35,51 @@ This is the (manual) process to update libraries in dispensary:
 6. Run `npm run update`
 7. Commit and push (Make sure to include `src/libraries.json`and `src/hashes.txt`)
 8. Tag and release
+
+## Development commands
+
+Here are some commands you can run:
+
+### `npm run build`
+
+This command builds the project.
+
+### `npm run clean`
+
+This command removes the build artifacts.
+
+### `npm run eslint`
+
+This command runs [eslint][] (JavaScript linter).
+
+### `npm run prettier`
+
+This command runs [pretty-quick][] to automatically compare and format modified source files against the master branch.
+
+### `npm run prettier-full`
+
+This command runs [Prettier][] to automatically format the entire codebase.
+
+### `npm run prettier-ci`
+
+This command runs [Prettier][] and fail if some code has been changed without being formatted.
+
+### `npm run test`
+
+This command builds the project and then runs the test suite (in watch mode).
+
+### `npm run test-coverage`
+
+This command builds the project, runs the test suite and then reports code coverage (codecov).
+
+### `npm run test-ci`
+
+This command runs all checks and is only useful in a CI context.
+
+### `bin/build-doc`
+
+This command updates the list of release pages in the `README.md` file based on the `src/libraries.json` file.
+
+[eslint]: https://eslint.org/
+[prettier]: https://prettier.io/
+[pretty-quick]: https://www.npmjs.com/package/pretty-quick

--- a/README.md
+++ b/README.md
@@ -11,19 +11,22 @@ This is the (manual) process to update libraries in dispensary:
 1. Open `src/libraries.json`
 2. Open the release pages of each library. Here is a list:
 
+<!--RELEASE_PAGES_START-->
+
 - https://github.com/angular/angular.js/releases
 - https://github.com/jashkenas/backbone/releases
 - https://github.com/twbs/bootstrap/releases
-- http://download.dojotoolkit.org/
+- https://download.dojotoolkit.org/
 - https://github.com/cure53/DOMPurify/releases
-- http://jquery.com/
-- http://jqueryui.com/
+- https://github.com/jquery/jquery/releases
+- https://github.com/jquery/jquery-ui/releases
 - https://github.com/moment/moment/releases
-- http://mootools.net/core
+- https://github.com/mootools/mootools-core/releases
 - http://prototypejs.org/
 - https://github.com/facebook/react/releases
 - https://github.com/jashkenas/underscore/releases
 - https://github.com/mozilla/webextension-polyfill/releases
+<!--RELEASE_PAGES_END-->
 
 3. On each page, check whether there are newer release versions than what is in `src/libraries.json`. Note that some libraries, like react, support several versions, so we need to check each "branch".
 4. For major upgrades, take a quick look at the code changes

--- a/README.md
+++ b/README.md
@@ -3,3 +3,31 @@
 # Dispensary 🌿
 
 The dispensary collects and offers hashes of popular JavaScript libraries, mainly for the [Mozilla's addons-linter](https://github.com/mozilla/addons-linter).
+
+## Libraries updates
+
+This is the (manual) process to update libraries in dispensary:
+
+1. Open `src/libraries.json`
+2. Open the release pages of each library. Here is a list:
+
+- https://github.com/angular/angular.js/releases
+- https://github.com/jashkenas/backbone/releases
+- https://github.com/twbs/bootstrap/releases
+- http://download.dojotoolkit.org/
+- https://github.com/cure53/DOMPurify/releases
+- http://jquery.com/
+- http://jqueryui.com/
+- https://github.com/moment/moment/releases
+- http://mootools.net/core
+- http://prototypejs.org/
+- https://github.com/facebook/react/releases
+- https://github.com/jashkenas/underscore/releases
+- https://github.com/mozilla/webextension-polyfill/releases
+
+3. On each page, check whether there are newer release versions than what is in `src/libraries.json`. Note that some libraries, like react, support several versions, so we need to check each "branch".
+4. For major upgrades, take a quick look at the code changes
+5. Add new versions to `src/libraries.json`
+6. Run `npm run update`
+7. Commit and push (Make sure to include `src/libraries.json`and `src/hashes.txt`)
+8. Tag and release

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This is the (manual) process to update libraries in dispensary:
 - https://github.com/facebook/react/releases
 - https://github.com/jashkenas/underscore/releases
 - https://github.com/mozilla/webextension-polyfill/releases
+
 <!--RELEASE_PAGES_END-->
 
 3. On each page, check whether there are newer release versions than what is in `src/libraries.json`. Note that some libraries, like react, support several versions, so we need to check each "branch".

--- a/bin/build-doc
+++ b/bin/build-doc
@@ -29,6 +29,6 @@ const content = releasePages
 
 replaceInFile.sync({
   files: README_FILE,
-  from: /(<!--RELEASE_PAGES_START-->\n)[\s\S]*(\n<!--RELEASE_PAGES_END-->)/,
+  from: /(<!--RELEASE_PAGES_START-->\n)[\s\S]*(\n\n<!--RELEASE_PAGES_END-->)/,
   to: `$1\n${content}$2`,
 });

--- a/bin/build-doc
+++ b/bin/build-doc
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const replaceInFile = require('replace-in-file');
+
+const PROJECT_ROOT = path.resolve(path.join(__dirname, '..'));
+const README_FILE = path.join(PROJECT_ROOT, 'README.md');
+const LIBRARIES_FILE = path.join(PROJECT_ROOT, 'src', 'libraries.json');
+
+const libraries = require(LIBRARIES_FILE);
+const releasePages = [
+  ...new Set(
+    libraries.map((library) => {
+      if (!library.releasePage) {
+        throw new Error(
+          `Missing 'releasePage' attribute for: ${library.name}.`,
+        );
+      }
+
+      return library.releasePage;
+    }),
+  ),
+];
+
+const content = releasePages
+  .map((releasePage) => `- ${releasePage}`)
+  .join('\n');
+
+replaceInFile.sync({
+  files: README_FILE,
+  from: /(<!--RELEASE_PAGES_START-->\n)[\s\S]*(\n<!--RELEASE_PAGES_END-->)/,
+  to: `$1\n${content}$2`,
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8439,6 +8439,44 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
+    "replace-in-file": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-5.0.2.tgz",
+      "integrity": "sha512-1Vc7Sbr/rTuHgU1PZuBb7tGsFx3D4NKdhV4BpEF2MuN/6+SoXcFtx+dZ1Zz+5Dq4k5x9js87Y+gXQYPTQ9ppkA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "glob": "^7.1.6",
+        "yargs": "^15.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "prettier": "1.19.1",
     "pretty-quick": "2.0.1",
     "raw-loader": "~4.0.0",
+    "replace-in-file": "5.0.2",
     "rimraf": "3.0.2",
     "sinon": "~9.0.0",
     "webpack": "~4.41.0",

--- a/src/libraries.json
+++ b/src/libraries.json
@@ -114,7 +114,8 @@
     ],
     "filename": "angular.js",
     "filenameMinified": "angular.min.js",
-    "url": "https://code.angularjs.org/$VERSION/$FILENAME"
+    "url": "https://code.angularjs.org/$VERSION/$FILENAME",
+    "releasePage": "https://github.com/angular/angular.js/releases"
   },
   {
     "name": "backbone",
@@ -134,7 +135,8 @@
     ],
     "filename": "backbone.js",
     "filenameMinified": "backbone-min.js",
-    "url": "https://raw.githubusercontent.com/jashkenas/backbone/$VERSION/$FILENAME"
+    "url": "https://raw.githubusercontent.com/jashkenas/backbone/$VERSION/$FILENAME",
+    "releasePage": "https://github.com/jashkenas/backbone/releases"
   },
   {
     "name": "bootstrap",
@@ -164,7 +166,8 @@
     ],
     "filename": "bootstrap.js",
     "filenameMinified": "bootstrap.min.js",
-    "url": "https://raw.githubusercontent.com/twbs/bootstrap/v$VERSION/dist/js/$FILENAME"
+    "url": "https://raw.githubusercontent.com/twbs/bootstrap/v$VERSION/dist/js/$FILENAME",
+    "releasePage": "https://github.com/twbs/bootstrap/releases"
   },
   {
     "name": "dojo",
@@ -246,7 +249,8 @@
     ],
     "filename": "dojo.js.uncompressed.js",
     "filenameMinified": "dojo.js",
-    "url": "https://download.dojotoolkit.org/release-$VERSION/$FILENAME"
+    "url": "https://download.dojotoolkit.org/release-$VERSION/$FILENAME",
+    "releasePage": "https://download.dojotoolkit.org/"
   },
   {
     "name": "dompurify",
@@ -275,7 +279,8 @@
     "filename": "purify.js",
     "filenameMinified": "purify.min.js",
     "url": "https://raw.githubusercontent.com/cure53/DOMPurify/$VERSION/dist/$FILENAME",
-    "urlMin": "https://raw.githubusercontent.com/cure53/DOMPurify/$VERSION/dist/$FILENAME"
+    "urlMin": "https://raw.githubusercontent.com/cure53/DOMPurify/$VERSION/dist/$FILENAME",
+    "releasePage": "https://github.com/cure53/DOMPurify/releases"
   },
   {
     "name": "jquery",
@@ -352,7 +357,8 @@
     "filenameOutput": "jquery.js",
     "filenameMinified": "jquery-$VERSION.min.js",
     "filenameMinifiedOutput": "jquery.min.js",
-    "url": "https://code.jquery.com/$FILENAME"
+    "url": "https://code.jquery.com/$FILENAME",
+    "releasePage": "https://github.com/jquery/jquery/releases"
   },
   {
     "name": "jquery-slim",
@@ -371,7 +377,8 @@
     "filenameOutput": "jquery.slim.js",
     "filenameMinified": "jquery-$VERSION.slim.min.js",
     "filenameMinifiedOutput": "jquery.slim.min.js",
-    "url": "https://code.jquery.com/$FILENAME"
+    "url": "https://code.jquery.com/$FILENAME",
+    "releasePage": "https://github.com/jquery/jquery/releases"
   },
   {
     "name": "jquery-ui",
@@ -391,7 +398,8 @@
     ],
     "filename": "jquery-ui.js",
     "filenameMinified": "jquery-ui.min.js",
-    "url": "https://code.jquery.com/ui/$VERSION/$FILENAME"
+    "url": "https://code.jquery.com/ui/$VERSION/$FILENAME",
+    "releasePage": "https://github.com/jquery/jquery-ui/releases"
   },
   {
     "name": "moment",
@@ -425,20 +433,23 @@
     "filename": "moment.js",
     "filenameMinified": "moment.min.js",
     "url": "https://raw.githubusercontent.com/moment/moment/$VERSION/$FILENAME",
-    "urlMin": "https://raw.githubusercontent.com/moment/moment/$VERSION/min/$FILENAME"
+    "urlMin": "https://raw.githubusercontent.com/moment/moment/$VERSION/min/$FILENAME",
+    "releasePage": "https://github.com/moment/moment/releases"
   },
   {
     "name": "mootools",
     "versions": ["1.5.1", "1.5.2", "1.6.0"],
     "filename": "mootools-core.js",
     "filenameMinified": "mootools-core.min.js",
-    "url": "https://raw.githubusercontent.com/mootools/mootools-core/$VERSION/dist/$FILENAME"
+    "url": "https://raw.githubusercontent.com/mootools/mootools-core/$VERSION/dist/$FILENAME",
+    "releasePage": "https://github.com/mootools/mootools-core/releases"
   },
   {
     "name": "prototype",
     "versions": ["1.7.0.0", "1.7.1.0", "1.7.2.0", "1.7.3.0"],
     "filename": "prototype.js",
-    "url": "https://ajax.googleapis.com/ajax/libs/prototype/$VERSION/$FILENAME"
+    "url": "https://ajax.googleapis.com/ajax/libs/prototype/$VERSION/$FILENAME",
+    "releasePage": "http://prototypejs.org/"
   },
   {
     "name": "react",
@@ -470,7 +481,8 @@
     ],
     "filename": "react.js",
     "filenameMinified": "react.min.js",
-    "url": "https://unpkg.com/react@$VERSION/dist/$FILENAME"
+    "url": "https://unpkg.com/react@$VERSION/dist/$FILENAME",
+    "releasePage": "https://github.com/facebook/react/releases"
   },
   {
     "name": "react16",
@@ -506,7 +518,8 @@
     ],
     "filename": "react.development.js",
     "filenameMinified": "react.production.min.js",
-    "url": "https://unpkg.com/react@$VERSION/umd/$FILENAME"
+    "url": "https://unpkg.com/react@$VERSION/umd/$FILENAME",
+    "releasePage": "https://github.com/facebook/react/releases"
   },
   {
     "name": "react-dom",
@@ -538,7 +551,8 @@
     ],
     "filename": "react-dom.js",
     "filenameMinified": "react-dom.min.js",
-    "url": "https://unpkg.com/react-dom@$VERSION/dist/$FILENAME"
+    "url": "https://unpkg.com/react-dom@$VERSION/dist/$FILENAME",
+    "releasePage": "https://github.com/facebook/react/releases"
   },
   {
     "name": "react-dom16",
@@ -574,7 +588,8 @@
     ],
     "filename": "react-dom.development.js",
     "filenameMinified": "react-dom.production.min.js",
-    "url": "https://unpkg.com/react-dom@$VERSION/umd/$FILENAME"
+    "url": "https://unpkg.com/react-dom@$VERSION/umd/$FILENAME",
+    "releasePage": "https://github.com/facebook/react/releases"
   },
   {
     "name": "underscore",
@@ -608,7 +623,8 @@
     ],
     "filename": "underscore.js",
     "filenameMinified": "underscore-min.js",
-    "url": "https://raw.github.com/jashkenas/underscore/$VERSION/$FILENAME"
+    "url": "https://raw.github.com/jashkenas/underscore/$VERSION/$FILENAME",
+    "releasePage": "https://github.com/jashkenas/underscore/releases"
   },
   {
     "name": "webextension-polyfill",
@@ -625,6 +641,7 @@
     ],
     "filename": "browser-polyfill.js",
     "filenameMinified": "browser-polyfill.min.js",
-    "url": "https://unpkg.com/webextension-polyfill@$VERSION/dist/$FILENAME"
+    "url": "https://unpkg.com/webextension-polyfill@$VERSION/dist/$FILENAME",
+    "releasePage": "https://github.com/mozilla/webextension-polyfill/releases"
   }
 ]


### PR DESCRIPTION
refs https://github.com/mozilla/dispensary/issues/702

---

This patch updates the README file with some docs for the different dev commands as well as a new section for the update workflow (heavily based on @wagnerand's comment). I also added a small script (not tested, ugh) to quickly build the list of release pages to check during this update process. CI should fail if the list is not up-to-date.